### PR TITLE
Add support for app check in authui widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1660,6 +1660,11 @@ have the following installed:
 - npm (should be included with Node.js)
 - Java SE Runtime Environment 8
 
+You may need to set JAVA_HOME to the correct path. For example, on macOS:
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
+```
+
 In order to run the demo and tests, you must also have:
 - Python (2.7)
 

--- a/firebase-externs/firebase-app-check-externs.js
+++ b/firebase-externs/firebase-app-check-externs.js
@@ -33,7 +33,7 @@ firebase.appCheck = function (app) {};
 firebase.appCheck.AppCheck = function () {};
 
 /**
- * @param {firebase.appCheck.ReCaptchaEnterpriseProvider} provider
+ * @param {firebase.appCheck.Provider} provider
  * @param {boolean} refresh
  */
 firebase.appCheck.AppCheck.prototype.activate = function (provider, refresh) {};
@@ -41,4 +41,4 @@ firebase.appCheck.AppCheck.prototype.activate = function (provider, refresh) {};
 /**
  * @constructor
  */
-firebase.appCheck.ReCaptchaEnterpriseProvider = function (appCheckToken) {};
+firebase.appCheck.Provider = function (appCheckToken) {};

--- a/firebase-externs/firebase-app-check-externs.js
+++ b/firebase-externs/firebase-app-check-externs.js
@@ -1,0 +1,44 @@
+/**
+ * @license Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Firebase App Check API.
+ * @externs
+ */
+
+/**
+ * @namespace
+ * @param {!firebase.app.App=} app
+ *
+ * @return {!firebase.appCheck.AppCheck}
+ */
+firebase.appCheck = function (app) {};
+
+/**
+ * @interface
+ */
+firebase.appCheck.AppCheck = function () {};
+
+/**
+ * @param {firebase.appCheck.ReCaptchaEnterpriseProvider} provider
+ * @param {boolean} refresh
+ */
+firebase.appCheck.AppCheck.prototype.activate = function (provider, refresh) {};
+
+/**
+ * @constructor
+ */
+firebase.appCheck.ReCaptchaEnterpriseProvider = function (appCheckToken) {};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,6 +66,7 @@ const MDL_COMPONENTS = [
 const ESM_DEPS = [
   'import firebase from \'firebase/compat/app\'',
   'import \'firebase/compat/auth\'',
+  'import \'firebase/compat/app-check\'',
   'import dialogPolyfill from \'dialog-polyfill\'',
 ].concat(MDL_COMPONENTS.map(component => `import \'material-design-lite/src/${component}\'`));
 
@@ -83,11 +84,11 @@ const ESM_EXPORT = 'var auth = firebaseui.auth;' +
 
 // Adds the cjs module requirement and exports firebaseui.
 const NPM_MODULE_WRAPPER = OPTIMIZATION_LEVEL === 'WHITESPACE_ONLY' ?
-    'var firebase=require(\'firebase/compat/app\');require(\'firebase/compat/auth\');' +
+    'var firebase=require(\'firebase/compat/app\');require(\'firebase/compat/auth\');require(\'firebase/compat/app-check\');' +
     DEFAULT_IMPORT_FIX + '%output%' + DIALOG_POLYFILL +
     'module.exports=firebaseui;' :
     '(function() { var firebase=require(\'firebase/compat/app\');' +
-    'require(\'firebase/compat/auth\');' + DEFAULT_IMPORT_FIX + '%output% ' +
+    'require(\'firebase/compat/auth\');' + 'require(\'firebase/compat/app-check\');' + DEFAULT_IMPORT_FIX + '%output% ' +
     DIALOG_POLYFILL + '})();' + 'module.exports=firebaseui;';
 
 // Adds the module requirement and exports firebaseui.
@@ -223,6 +224,7 @@ function buildFirebaseUiJs(locale) {
     define: `goog.LOCALE='${locale}'`,
     externs: [
       'firebase-externs/firebase-app-externs.js',
+      'firebase-externs/firebase-app-check-externs.js',
       'firebase-externs/firebase-auth-externs.js',
       'firebase-externs/firebase-client-auth-externs.js'
     ],

--- a/javascript/widgets/authui.js
+++ b/javascript/widgets/authui.js
@@ -99,10 +99,10 @@ goog.requireType('firebaseui.auth.ui.page.Base');
 /**
  * @param {!firebase.auth.Auth} auth The Firebase Auth instance.
  * @param {string=} opt_appId The optional app id.
- * @param {string=} appCheckToken The optional app id.
+ * @param {firebase.appCheck.Provider=} appCheckProvider The optional app check provider.
  * @constructor @struct
  */
-firebaseui.auth.AuthUI = function(auth, opt_appId, appCheckToken) {
+firebaseui.auth.AuthUI = function(auth, opt_appId, appCheckProvider) {
   /** @private {boolean} Whether the current instance is deleted. */
   this.deleted_ = false;
   // Check if an instance with the same key exists. If so, throw an error,
@@ -128,12 +128,10 @@ firebaseui.auth.AuthUI = function(auth, opt_appId, appCheckToken) {
   var tempApp = firebase.initializeApp({
     ...auth['app']['options']
   }, auth['app']['name'] + firebaseui.auth.AuthUI.TEMP_APP_NAME_SUFFIX_);
-  if (appCheckToken) {
+  if (appCheckProvider) {
     const appCheck = firebase.appCheck(tempApp);
     appCheck.activate(
-        new firebase.appCheck.ReCaptchaEnterpriseProvider(
-            appCheckToken
-        ),
+        appCheckProvider,
         true // Set to true to allow auto-refresh.
     );
   }

--- a/javascript/widgets/authui.js
+++ b/javascript/widgets/authui.js
@@ -99,9 +99,10 @@ goog.requireType('firebaseui.auth.ui.page.Base');
 /**
  * @param {!firebase.auth.Auth} auth The Firebase Auth instance.
  * @param {string=} opt_appId The optional app id.
+ * @param {string=} appCheckToken The optional app id.
  * @constructor @struct
  */
-firebaseui.auth.AuthUI = function(auth, opt_appId) {
+firebaseui.auth.AuthUI = function(auth, opt_appId, appCheckToken) {
   /** @private {boolean} Whether the current instance is deleted. */
   this.deleted_ = false;
   // Check if an instance with the same key exists. If so, throw an error,
@@ -125,9 +126,17 @@ firebaseui.auth.AuthUI = function(auth, opt_appId) {
   // Log FirebaseUI on external Auth instance.
   firebaseui.auth.AuthUI.logFirebaseUI_(this.auth_);
   var tempApp = firebase.initializeApp({
-    'apiKey': auth['app']['options']['apiKey'],
-    'authDomain': auth['app']['options']['authDomain']
+    ...auth['app']['options']
   }, auth['app']['name'] + firebaseui.auth.AuthUI.TEMP_APP_NAME_SUFFIX_);
+  if (appCheckToken) {
+    const appCheck = firebase.appCheck(tempApp);
+    appCheck.activate(
+        new firebase.appCheck.ReCaptchaEnterpriseProvider(
+            appCheckToken
+        ),
+        true // Set to true to allow auto-refresh.
+    );
+  }
   /**
    * @private {!firebase.auth.Auth} The temporary internal Firebase Auth
    *     instance.


### PR DESCRIPTION
# Description

Adds support for App Check. AuthUI initialization takes a third parameter, which is an entire app check provider. This will make it easy to switch providers as needed without having to update this code.